### PR TITLE
fix: login시 token과 id, role 등을 같이 반환하는 이슈 해결

### DIFF
--- a/src/main/java/com/example/demo/admin/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/example/demo/admin/dto/response/AdminLoginResponse.java
@@ -1,20 +1,12 @@
 package com.example.demo.admin.dto.response;
 
-import com.example.demo.common.util.auth.Role;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @Schema(name = "AdminLoginResponse", description = "관리자 로그인 응답")
-public record AdminLoginResponse(@Schema(description = "관리자 ID", requiredMode = Schema.RequiredMode.REQUIRED)
-								 Long id,
-								 @Schema(description = "로그인한 관리자 이름", requiredMode = Schema.RequiredMode.REQUIRED)
-								 String name,
-								 @Schema(description = "Access Token", requiredMode = Schema.RequiredMode.REQUIRED)
+public record AdminLoginResponse(@Schema(description = "Access Token", requiredMode = Schema.RequiredMode.REQUIRED)
 								 String accessToken,
 								 @Schema(description = "Refresh Token", requiredMode = Schema.RequiredMode.REQUIRED)
-								 String refreshToken,
-								 @Schema(description = "Role", requiredMode = Schema.RequiredMode.REQUIRED)
-								 Role role) {
+								 String refreshToken) {
 }

--- a/src/main/java/com/example/demo/admin/service/AdminService.java
+++ b/src/main/java/com/example/demo/admin/service/AdminService.java
@@ -40,11 +40,8 @@ public class AdminService {
 		adminAuth.updateRefreshToken(refreshToken);
 
 		return AdminLoginResponse.builder()
-			.id(admin.getId())
-			.name(admin.getName())
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
-			.role(admin.getRole())
 			.build();
 	}
 

--- a/src/main/java/com/example/demo/customer/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/demo/customer/dto/response/LoginResponse.java
@@ -1,18 +1,12 @@
 package com.example.demo.customer.dto.response;
 
-import com.example.demo.common.util.auth.Role;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @Schema(name = "LoginResponse", description = "로그인 응답")
-public record LoginResponse(@Schema(description = "로그인한 유저 id", requiredMode = Schema.RequiredMode.REQUIRED)
-							Long customerId,
-							@Schema(description = "Access Token", requiredMode = Schema.RequiredMode.REQUIRED)
+public record LoginResponse(@Schema(description = "Access Token", requiredMode = Schema.RequiredMode.REQUIRED)
 							String accessToken,
 							@Schema(description = "Refresh Token", requiredMode = Schema.RequiredMode.REQUIRED)
-							String refreshToken,
-							@Schema(description = "Role", requiredMode = Schema.RequiredMode.REQUIRED)
-							Role role) {
+							String refreshToken) {
 }

--- a/src/main/java/com/example/demo/customer/service/CustomerService.java
+++ b/src/main/java/com/example/demo/customer/service/CustomerService.java
@@ -1,34 +1,35 @@
 package com.example.demo.customer.service;
 
-import com.example.demo.customer.dto.request.AddAddressRequest;
-import com.example.demo.customer.dto.request.AddPaymentRequest;
-import com.example.demo.customer.dto.request.UpdateAddressRequest;
-import com.example.demo.customer.dto.request.UpdatePaymentRequest;
-import com.example.demo.customer.dto.response.GetAddressDetailResponse;
-import com.example.demo.customer.dto.response.GetAddressResponse;
-import com.example.demo.customer.dto.response.GetPaymentDetailResponse;
-import com.example.demo.customer.dto.response.GetPaymentResponse;
-import com.example.demo.customer.entity.Address;
-import com.example.demo.customer.entity.Payment;
+import java.util.List;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.common.exception.CustomException;
 import com.example.demo.common.security.TokenProvider;
-import com.example.demo.common.util.auth.AuthService;
-import com.example.demo.customer.dto.request.ProfileUpdateRequest;
-import com.example.demo.customer.dto.response.GetCustomerResponse;
-import com.example.demo.customer.dto.response.LoginResponse;
-import com.example.demo.customer.entity.Customer;
 import com.example.demo.common.util.auth.Auth;
+import com.example.demo.common.util.auth.AuthService;
+import com.example.demo.customer.dto.request.AddAddressRequest;
+import com.example.demo.customer.dto.request.AddPaymentRequest;
+import com.example.demo.customer.dto.request.ProfileUpdateRequest;
+import com.example.demo.customer.dto.request.UpdateAddressRequest;
+import com.example.demo.customer.dto.request.UpdatePaymentRequest;
+import com.example.demo.customer.dto.response.GetAddressDetailResponse;
+import com.example.demo.customer.dto.response.GetAddressResponse;
+import com.example.demo.customer.dto.response.GetCustomerResponse;
+import com.example.demo.customer.dto.response.GetPaymentDetailResponse;
+import com.example.demo.customer.dto.response.GetPaymentResponse;
+import com.example.demo.customer.dto.response.LoginResponse;
+import com.example.demo.customer.entity.Address;
+import com.example.demo.customer.entity.Customer;
+import com.example.demo.customer.entity.Payment;
 import com.example.demo.customer.repository.CustomerRepository;
 import com.example.demo.exception.CustomerAuthNotFoundException;
 import com.example.demo.exception.CustomerErrorCode;
 import com.example.demo.exception.CustomerNotFoundException;
 
 import lombok.RequiredArgsConstructor;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -66,10 +67,8 @@ public class CustomerService {
 		auth.updateRefreshToken(refreshToken);
 
 		return LoginResponse.builder()
-			.customerId(customer.getId())
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
-			.role(customer.getRole())
 			.build();
 	}
 


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
* Admin 및 Customer 로그인 api가 수행되었을 때 token과 id, role 등을 함께 반환하는 이슈를 해결한다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
* AdminLoginResponse와 CustomerLoginResponse의 column을 accessToken과 refreshToken만 남긴다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
* x

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
* x
