### PR TITLE
fix: 회원정보 수정시 auth code 반영이 안되는 이슈 수정

### DIFF
--- a/src/main/java/com/example/demo/common/util/auth/Auth.java
+++ b/src/main/java/com/example/demo/common/util/auth/Auth.java
@@ -37,4 +37,8 @@ public class Auth {
 	public void logout() {
 		this.refreshToken = null;
 	}
+
+	public void update(String email) {
+		this.code = email;
+	}
 }

--- a/src/main/java/com/example/demo/common/util/auth/AuthService.java
+++ b/src/main/java/com/example/demo/common/util/auth/AuthService.java
@@ -20,4 +20,9 @@ public class AuthService {
 		return authRepository.findByCode(code)
 			.orElseThrow(CustomerAuthNotFoundException::new);
 	}
+
+	public void update(String email, String newCode) {
+		Auth auth = findByCode(email);
+		auth.update(newCode);
+	}
 }

--- a/src/main/java/com/example/demo/customer/service/CustomerService.java
+++ b/src/main/java/com/example/demo/customer/service/CustomerService.java
@@ -1,34 +1,35 @@
 package com.example.demo.customer.service;
 
-import com.example.demo.customer.dto.request.AddAddressRequest;
-import com.example.demo.customer.dto.request.AddPaymentRequest;
-import com.example.demo.customer.dto.request.UpdateAddressRequest;
-import com.example.demo.customer.dto.request.UpdatePaymentRequest;
-import com.example.demo.customer.dto.response.GetAddressDetailResponse;
-import com.example.demo.customer.dto.response.GetAddressResponse;
-import com.example.demo.customer.dto.response.GetPaymentDetailResponse;
-import com.example.demo.customer.dto.response.GetPaymentResponse;
-import com.example.demo.customer.entity.Address;
-import com.example.demo.customer.entity.Payment;
+import java.util.List;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.common.exception.CustomException;
 import com.example.demo.common.security.TokenProvider;
-import com.example.demo.common.util.auth.AuthService;
-import com.example.demo.customer.dto.request.ProfileUpdateRequest;
-import com.example.demo.customer.dto.response.GetCustomerResponse;
-import com.example.demo.customer.dto.response.LoginResponse;
-import com.example.demo.customer.entity.Customer;
 import com.example.demo.common.util.auth.Auth;
+import com.example.demo.common.util.auth.AuthService;
+import com.example.demo.customer.dto.request.AddAddressRequest;
+import com.example.demo.customer.dto.request.AddPaymentRequest;
+import com.example.demo.customer.dto.request.ProfileUpdateRequest;
+import com.example.demo.customer.dto.request.UpdateAddressRequest;
+import com.example.demo.customer.dto.request.UpdatePaymentRequest;
+import com.example.demo.customer.dto.response.GetAddressDetailResponse;
+import com.example.demo.customer.dto.response.GetAddressResponse;
+import com.example.demo.customer.dto.response.GetCustomerResponse;
+import com.example.demo.customer.dto.response.GetPaymentDetailResponse;
+import com.example.demo.customer.dto.response.GetPaymentResponse;
+import com.example.demo.customer.dto.response.LoginResponse;
+import com.example.demo.customer.entity.Address;
+import com.example.demo.customer.entity.Customer;
+import com.example.demo.customer.entity.Payment;
 import com.example.demo.customer.repository.CustomerRepository;
 import com.example.demo.exception.CustomerAuthNotFoundException;
 import com.example.demo.exception.CustomerErrorCode;
 import com.example.demo.exception.CustomerNotFoundException;
 
 import lombok.RequiredArgsConstructor;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -82,6 +83,7 @@ public class CustomerService {
 	@Transactional
 	public void updateProfile(Long customerId, ProfileUpdateRequest profileUpdateRequest) {
 		Customer customer = customerRepository.getReferenceById(customerId);
+		authService.update(customer.getEmail(), profileUpdateRequest.email());
 		customer.update(profileUpdateRequest.email(), profileUpdateRequest.name(), profileUpdateRequest.nickName(),
 			profileUpdateRequest.age(), profileUpdateRequest.phoneNumber());
 	}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
* 회원 정보 수정 API를 통해 이메일을 변경했을 때 변경된 이메일로 로그인 되지 않는 이슈 수정

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
* CustomerService의 updateProfile 메서드에 authService.update 메서드 추가

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요? 
* x

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
* x
